### PR TITLE
add VCD cloud-provider app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add initial default apps.
+- Add `cloud-provider-cloud-director` at `v0.1.0`.
 
 [Unreleased]: https://github.com/giantswarm/default-apps-cloud-director/tree/main

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -35,6 +35,16 @@ apps:
     forceUpgrade: false
     namespace: kube-system
     version: 0.1.0
+  cloudProviderCloudDirector:
+    appName: cloud-provider-cloud-director
+    chartName: cloud-provider-cloud-director
+    catalog: default
+    clusterValues:
+      configMap: false
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    version: 0.1.0
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources


### PR DESCRIPTION
This PR:

- adds `cloud-provider-cloud-director` app at v0.1.0

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
