### PR TITLE
Provide `<wc-name>-cluster-values`  secret to cloud-provider-cloud-director app

### DIFF
--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -57,7 +57,7 @@ apps:
     catalog: default
     clusterValues:
       configMap: true
-      secret: false
+      secret: true
     forceUpgrade: true
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23663

Thanks to this PR, we will provide values in `<wc-name>-cluster-values` secret to `cloud-provider-cloud-director` app.

Complementary of https://github.com/giantswarm/cluster-apps-operator/pull/287

### Testing

Description on how default-apps-cloud-director can be tested.

- [x] fresh install works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
