### PR TITLE
Bump cloud-provider-cloud-director-app to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.1] - 2022-11-14
-
 ### Changed
 
-- Use `clusterValues` `secret` for `cert-manager` (requried to create a fresh cluster behind a proxy.
+- Bump `cloud-provider-cloud-director-app` version to `0.1.3`.
+
+## [0.2.1] - 2022-11-14
+
+
+
+
 - Set `ipam` mode from `cluster-pool` to `kubernetes` for cilium cni.
 
 ## [0.2.0] - 2022-10-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.1] - 2022-11-14
 
+### Changed
 
-
-
+- Use `clusterValues` `secret` for `cert-manager` (requried to create a fresh cluster behind a proxy.
 - Set `ipam` mode from `cluster-pool` to `kubernetes` for cilium cni.
 
 ## [0.2.0] - 2022-10-17

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -68,7 +68,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/cloud-provider-cloud-director-app
-    version: 0.1.2
+    version: 0.1.3
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources


### PR DESCRIPTION
Bumps cloud-provider-cloud-director version to 0.1.3 to consume the fix here 
https://github.com/giantswarm/cloud-provider-cloud-director-app/pull/21

### Testing

Description on how default-apps-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
