### PR TITLE
Update observability bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `observability-bundle` from `0.1.3` to `0.1.4`
+
 ## [0.3.0] - 2022-12-06
 
 ### Added

--- a/helm/default-apps-cloud-director/values.schema.json
+++ b/helm/default-apps-cloud-director/values.schema.json
@@ -133,6 +133,9 @@
                         "inCluster": {
                             "type": "boolean"
                         },
+                        "forceUpgrade": {
+                            "type": "boolean"
+                        },
                         "namespace": {
                             "type": "string"
                         },

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -138,7 +138,7 @@ apps:
       secret: false
     forceUpgrade: false
     inCluster: true
-    namespace: "kube-system"
+    namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.1.3
+    version: 0.1.4


### PR DESCRIPTION
This PR:

- Updates the observability bundle to not counteract with prometheus-meta-operator

### Testing

Description on how default-apps-cloud-director can be tested.

- [x] fresh install works
- [x] upgrade from previous version works

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
