### PR TITLE
Add vertical-pod-autoscaler{-crd} to default apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `vertical-pod-autoscaler@2.5.3` & `vertical-pod-autoscaler-crd@1.0.1`.
+
 ## [0.3.5] - 2023-01-18
 
 ### Changed

--- a/helm/default-apps-cloud-director/values.schema.json
+++ b/helm/default-apps-cloud-director/values.schema.json
@@ -153,3 +153,4 @@
         "managementCluster"
     ]
 }
+

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -142,3 +142,27 @@ apps:
     # used by renovate
     # repo: giantswarm/observability-bundle
     version: 0.1.9
+  vpa:
+    appName: vertical-pod-autoscaler
+    chartName: vertical-pod-autoscaler-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/vertical-pod-autoscaler-app
+    version: 2.5.3
+  vpaCRD:
+    appName: vertical-pod-autoscaler-crd
+    chartName: vertical-pod-autoscaler-crd
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/vertical-pod-autoscaler-crd
+    version: 1.0.1


### PR DESCRIPTION
Issue: https://github.com/giantswarm/giantswarm/issues/24783

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Adds `vertical-pod-autoscaler` and `vertical-pod-autoscaler-crd`

### Testing

Description on how default-apps-cloud-director can be tested.

- [x] fresh install works
- [x] upgrade from previous version works

Tested on guppy (output from WC):
```bash
λ k get deploy -A | grep vert                                                                                               ○ jiri3-admin@jiri3
kube-system   vertical-pod-autoscaler-admission-controller   2/2     2            2           23m
kube-system   vertical-pod-autoscaler-recommender            1/1     1            1           23m
kube-system   vertical-pod-autoscaler-updater                1/1     1            1           23m
```
<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
