### PR TITLE
Enable configuration of Apps with the extraConfig key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New app dependency mechanism (`app-operator.giantswarm.io/depends-on`) to the vertical-pod-autoscaler-app it is not installed until the corresponding CRD app is deployed.
+- Enable configuration of Apps with the [extraConfig](https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#enhancing-app-cr) key.
 
 ## [0.4.1] - 2023-03-25
 

--- a/helm/default-apps-cloud-director/templates/apps.yaml
+++ b/helm/default-apps-cloud-director/templates/apps.yaml
@@ -50,6 +50,14 @@ spec:
   {{- end }}
   {{- end }}
 {{- end }}
+{{- if .extraConfigs }}
+  extraConfigs:
+  {{- range .extraConfigs }}
+  - kind: {{ .kind }}
+    name: {{ .name }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+ {{- end }}
 {{- with (get $.Values.userConfig $key) }}
   userConfig:
   {{- if .configMap }}

--- a/helm/default-apps-cloud-director/values.schema.json
+++ b/helm/default-apps-cloud-director/values.schema.json
@@ -32,6 +32,19 @@
                     "dependsOn": {
                         "type": "string"
                     },
+                    "extraConfigs": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "kind": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
                     "forceUpgrade": {
                         "type": "boolean"
                     },


### PR DESCRIPTION
This PR:

- enables configuration of Apps with the optional extraConfig key

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

sample values.yaml:

```
apps:
    certManager:
    appName: cert-manager
    chartName: cert-manager-app
    catalog: default
    clusterValues:
      configMap: true
      secret: true
    extraConfigs:
      - kind: Secret
        name: leopard-cert-manager-user-secrets
    forceUpgrade: true
    namespace: kube-system
    # used by renovate
    # repo: giantswarm/cert-manager-app
    version: 2.20.3
```

generates the following AppCR spec:

```
spec:
  catalog: default
  name: cert-manager-app
  namespace: kube-system
  kubeConfig:
    context:
      name: test-admin@test
    inCluster: false
    secret:
      name: test-kubeconfig
      namespace: org-giantswarm
  version: 2.20.3
  config:
    configMap:
      name: test-cluster-values
      namespace: org-giantswarm
    secret:
      name: test-cluster-values
      namespace: org-giantswarm
  extraConfigs:
  - kind: Secret
    name: leopard-cert-manager-user-secrets
    namespace: org-giantswarm
```
