### PR TITLE
change default clusterIssuer to letsencrypt-giantswarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `net-exporter` version to `1.14.0`.
 - Bump `metrics-server-app` version to `2.1.0`.
 - Bump `cert-exporter` version to `2.4.0`.
+- Change default clusterIssuer from `private-giantswarm` to `letsencrypt-giantswarm`.
 
 ## [0.5.0] - 2023-03-29
 

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -13,6 +13,12 @@ userConfig:
       values: |
         disableConntrackCollector: true
         disableNvmeCollector: true
+  certManager:
+    configMap:
+      values: |
+        controller:
+          defaultIssuer:
+            name: letsencrypt-giantswarm
 
 apps:
   certExporter:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26470

By default the default clusterIssuer is `private-giantswarm` which doesn't exist, causing some deployments using default issue to fail get certificates (observability bundle).

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
