### PR TITLE
Bump Observability Bundle to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `observability-bundle` to `0.4.0`.
+
+### Removed
+
+- Remove kube-state-metrics app as it is now included in the observability-bundle.
+
 ## [0.5.1] - 2023-04-13
 
 ### Changed

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -45,18 +45,6 @@ apps:
     # used by renovate
     # repo: giantswarm/cert-manager-app
     version: 2.21.0
-  kubeStateMetrics:
-    appName: kube-state-metrics
-    chartName: kube-state-metrics
-    catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
-    forceUpgrade: true
-    namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/kube-state-metrics-app
-    version: 1.15.0
   metricsServer:
     appName: metrics-server
     chartName: metrics-server-app
@@ -105,7 +93,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.3.0
+    version: 0.4.0
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26221

### What this PR does / why we need it
This PR bumps the observability bundle and remove kube-state-metrics as it is now included

### Testing

Description on how default-apps-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works


### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
