### PR TITLE
Bump observability-bundle to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `observability-bundle` to `0.4.1`.
+- Bump `observability-bundle` to `0.4.2`.
 
 ### Fixed
 

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -93,7 +93,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.4.1
+    version: 0.4.2
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

towards https://github.com/giantswarm/giantswarm/issues/26674

Bump observability-bundle to 0.4.2: fix preStop with removing the wal directory in the prometheus-agent

### Testing

Description on how default-apps-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
