### PR TITLE
Fix cluster DNS service name for net-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix missing schema for `certManager` config.
+- Fix cluster DNS service name for `net-exporter` (`kube-dns` -> `coredns`).
 
 ## [0.5.2] - 2023-04-13
 

--- a/helm/default-apps-cloud-director/values.schema.json
+++ b/helm/default-apps-cloud-director/values.schema.json
@@ -87,19 +87,6 @@
         "userConfig": {
             "type": "object",
             "properties": {
-                "netExporter": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "values": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
                 "nodeExporter": {
                     "type": "object",
                     "properties": {

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -3,11 +3,6 @@ organization: ""
 managementCluster: ""
 
 userConfig:
-  netExporter:
-    configMap:
-      values: |
-        dns:
-          service: kube-dns
   nodeExporter:
     configMap:
       values: |


### PR DESCRIPTION
Incident: https://gigantic.slack.com/archives/C058U5RSAPM

We are deploying `coredns` with `coredns-app` now so the service name is taken from the app instead of kubeadm default.

Sibling of https://github.com/giantswarm/default-apps-vsphere/pull/87