### PR TITLE
Add the annotation back to prevent paging about node-exporter not bei…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `podAnnotations` for `node-exporter` app to be able to collect systemd-related metrics.
+
 ## [0.6.3] - 2023-09-20
 
 ### Changed

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -49,6 +49,9 @@ userConfig:
       values: |
         disableConntrackCollector: true
         disableNvmeCollector: true
+        # remove the pod annotation once we use flatcar images
+        podAnnotations:
+          container.apparmor.security.beta.kubernetes.io/node-exporter: "unconfined"
   vpa:
     configMap:
       values: |


### PR DESCRIPTION
…ng able to collect systemd-related metrics

Same thing as this for vsphere: https://github.com/giantswarm/default-apps-vsphere/pull/129

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how default-apps-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
