### PR TITLE
Fix `extraConfigs` range operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `chart-operator-extension` version `v1.1.1` that contains e.g. `ServiceMonitors` for `chart-operator`.
 
+### Fixed
+
+- Fix `extraConfigs` range operator
+
 ## [0.6.4] - 2023-09-22
 
 ### Added

--- a/helm/default-apps-cloud-director/templates/apps.yaml
+++ b/helm/default-apps-cloud-director/templates/apps.yaml
@@ -52,9 +52,9 @@ spec:
 {{- end }}
 {{- if .extraConfigs }}
   extraConfigs:
-  {{- range .extraConfigs }}
-  - kind: {{ .kind }}
-    name: {{ .name }}
+  {{- range $extraConfig := .extraConfigs }}
+  - kind: {{ $extraConfig.kind }}
+    name: {{ tpl $extraConfig.name $ }}
     namespace: {{ $.Release.Namespace }}
   {{- end }}
  {{- end }}


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- Fixes the following issue with `extraConfigs` range operator

In values.yaml
```
  teleportKubeAgent:
    ...
    extraConfigs:
    - kind: configMap
      name: "{{ $.Values.clusterName }}-teleport-kube-agent-config"
```

Helm template results:
```
> helm template helm/default-apps-cloud-director/ -f helm/default-apps-cloud-director/ci/ci-values.yaml
Error: YAML parse error on default-apps-cloud-director/templates/apps.yaml: error converting YAML to JSON: yaml: line 39: did not find expected key

Use --debug flag to render out invalid YAML
```



### Testing

Description on how default-apps-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
