### PR TITLE
Reduce k8s resource count exporter app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `extraConfigs` range operator
+- Shortened `etcd-kubernetes-resources-count-exporter` appName to `etcd-k8s-res-count-exporter`.
 
 ## [0.6.4] - 2023-09-22
 

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -96,7 +96,7 @@ apps:
     # repo: giantswarm/chart-operator-extensions
     version: 1.1.1
   etcdKubernetesResourceCountExporter:
-    appName: etcd-kubernetes-resources-count-exporter
+    appName: etcd-k8s-res-count-exporter
     chartName: etcd-kubernetes-resources-count-exporter
     catalog: default
     clusterValues:


### PR DESCRIPTION
This reduces the etcd-kubernetes-resources-count-exporter appName that was causing the default-apps installation to fail in clusters having longer names.

Towards https://github.com/giantswarm/giantswarm/issues/28911

Same PR for CAPA: https://github.com/giantswarm/default-apps-aws/pull/361

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
