### PR TITLE
Add security bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `security-bundle` app.
+
 ### Changed
 
 - Bump observability-bundle to 1.0.0. Beware that this version contains breaking changes

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -188,6 +188,19 @@ apps:
     # used by renovate
     # repo: giantswarm/observability-bundle
     version: 1.0.0
+  securityBundle:
+    appName: security-bundle
+    chartName: security-bundle
+    catalog: giantswarm
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    inCluster: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/security-bundle
+    version: 1.5.0
   teleportKubeAgent:
     appName: teleport-kube-agent
     chartName: teleport-kube-agent

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -200,7 +200,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/security-bundle
-    version: 1.5.0
+    version: 0.21.0
   teleportKubeAgent:
     appName: teleport-kube-agent
     chartName: teleport-kube-agent


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

Towards v1.25 https://github.com/giantswarm/roadmap/issues/3144

We default the security bundle version to `0.21.0` with PSPs, Kyverno and the policies in audit mode.

Context: https://gigantic.slack.com/archives/C01BYMF6RN0/p1706272237014029?thread_ts=1706197935.785989&cid=C01BYMF6RN0

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how default-apps-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
