### PR TITLE
Bump observability bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `observability-bundle` to `v1.2.1`.
+
 ## [0.7.2] - 2024-01-30
 
 ### Added

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -52,38 +52,6 @@ userConfig:
         # remove the pod annotation once we use flatcar images
         podAnnotations:
           container.apparmor.security.beta.kubernetes.io/node-exporter: "unconfined"
-  observabilityBundle:
-    configMap:
-      values:
-        userConfig:
-          kubePrometheusStack:
-            configMap:
-              values:
-                global:
-                  rbac:
-                    pspEnabled: true
-                kube-prometheus-stack:
-                  grafana:
-                    rbac:
-                      pspEnabled: true
-                  kube-state-metrics:
-                    podSecurityPolicy:
-                      enabled: true
-                  prometheus-node-exporter:
-                    rbac:
-                      pspEnabled: true
-          prometheusAgent:
-            configMap:
-              values:
-                prometheus-agent:
-                  psp:
-                    enabled: true
-          promtail:
-            configMap:
-              values:
-                promtail:
-                  rbac:
-                    pspEnabled: true
   vpa:
     configMap:
       values:
@@ -187,7 +155,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 1.0.0
+    version: 1.2.1
   securityBundle:
     appName: security-bundle
     chartName: security-bundle


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- upgrades the olly bundle and adds back the pss toggle for the bundled apps

### Testing

Description on how default-apps-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
