### PR TITLE
Add cilium-servicemonitors app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `cilium-servicemonitors` app.
+
 ## [0.7.4] - 2024-02-15
 
 ### Changed

--- a/helm/default-apps-cloud-director/values.schema.json
+++ b/helm/default-apps-cloud-director/values.schema.json
@@ -86,6 +86,9 @@
                 "chartOperatorExtensions": {
                     "$ref": "#/$defs/app"
                 },
+                "ciliumServiceMonitors": {
+                    "$ref": "#/$defs/app"
+                },
                 "clusterResources": {
                     "$ref": "#/$defs/app"
                 },

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -95,6 +95,18 @@ apps:
     # used by renovate
     # repo: giantswarm/chart-operator-extensions
     version: 1.1.2
+  ciliumServiceMonitors:
+    appName: cilium-servicemonitors
+    chartName: cilium-servicemonitors
+    catalog: default
+    clusterValues:
+      configMap: false
+      secret: false
+    dependsOn: prometheus-operator-crd
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/cilium-servicemonitors-app
+    version: 0.1.2
   etcdKubernetesResourceCountExporter:
     appName: etcd-k8s-res-count-exporter
     chartName: etcd-kubernetes-resources-count-exporter


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR adds cilium-servicemonitors app

Towards https://github.com/giantswarm/roadmap/issues/3283

### Testing

Description on how default-apps-cloud-director can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.



### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`
If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites