### PR TITLE
Downgrade VPA due to an upstream bug.

### DIFF
--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -229,7 +229,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/vertical-pod-autoscaler-app
-    version: 5.2.1
+    version: 5.1.0
   vpaCRD:
     appName: vertical-pod-autoscaler-crd
     chartName: vertical-pod-autoscaler-crd
@@ -241,4 +241,4 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/vertical-pod-autoscaler-crd
-    version: 3.1.0
+    version: 3.0.0


### PR DESCRIPTION
This PR:
- downgrades VPA and VPA CRD to 5.1.0/3.0.0 due to an upstream bug that causes the updater to panic.

Refs:
https://github.com/giantswarm/roadmap/issues/3421
https://github.com/kubernetes/autoscaler/issues/6763
https://github.com/kubernetes/autoscaler/issues/6808

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
