### PR TITLE
Enable migration of apps to cluster-cloud-director

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> [!WARNING]
+> This release includes changes that enable the unification of cluster-cloud-director and default-apps-cloud-director. The unification
+> of cluster-cloud-director and default-apps-cloud-director does not happen automatically, it must be enabled explicitly and even then
+> it requires manual steps.
+
+**See `cluster-cloud-director` [changelog](https://github.com/giantswarm/cluster-cloud-director/blob/main/CHANGELOG.md#0620---2024-10-21) for the upgrade walkthrough.**
+
+### Added
+
+- New Helm value `.Values.deleteOptions.moveAppsHelmOwnershipToClusterCloudDirector`, which, when enabled, will pause all apps in the default-apps-cloud-director, and it will enable the below hooks. The apps are paused in order to prevent the deletion of Chart resources in the WC.
+- Helm hook to remove app-operator finalizer from App CRs, so that App CRs are deleted from the MC, while Chart CRs stay on the WC.
+- Helm hook to propagate pause annotation to all bundled apps.
+
 ## [0.10.0] - 2024-10-01
 
 ### Added

--- a/helm/default-apps-cloud-director/README.md
+++ b/helm/default-apps-cloud-director/README.md
@@ -4,8 +4,7 @@ This page lists all available configuration options, based on the [configuration
 
 <!-- DOCS_START -->
 
-### User Config
-
+### 
 Properties within the `.userConfig` top-level object
 
 | **Property** | **Description** | **More Details** |
@@ -29,8 +28,7 @@ Properties within the `.userConfig` top-level object
 | `userConfig.vpa.configMap` |**None**|**Type:** `object`<br/>|
 | `userConfig.vpa.configMap.values` |**None**|**Types:** `object, string`<br/>|
 
-### Apps
-
+### 
 Properties within the `.apps` top-level object
 
 | **Property** | **Description** | **More Details** |
@@ -115,6 +113,22 @@ Properties within the `.apps` top-level object
 | `apps.clusterResources.inCluster` |**None**|**Type:** `boolean`<br/>|
 | `apps.clusterResources.namespace` |**None**|**Type:** `string`<br/>|
 | `apps.clusterResources.version` |**None**|**Type:** `string`<br/>|
+| `apps.k8sDnsNodeCache` |**None**|**Type:** `object`<br/>|
+| `apps.k8sDnsNodeCache.appName` |**None**|**Type:** `string`<br/>|
+| `apps.k8sDnsNodeCache.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.k8sDnsNodeCache.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.k8sDnsNodeCache.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.k8sDnsNodeCache.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.k8sDnsNodeCache.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.k8sDnsNodeCache.dependsOn` |**None**|**Type:** `string`<br/>|
+| `apps.k8sDnsNodeCache.extraConfigs` |**None**|**Type:** `array`<br/>|
+| `apps.k8sDnsNodeCache.extraConfigs[*]` |**None**||
+| `apps.k8sDnsNodeCache.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
+| `apps.k8sDnsNodeCache.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
+| `apps.k8sDnsNodeCache.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.k8sDnsNodeCache.inCluster` |**None**|**Type:** `boolean`<br/>|
+| `apps.k8sDnsNodeCache.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.k8sDnsNodeCache.version` |**None**|**Type:** `string`<br/>|
 | `apps.metricsServer` |**None**|**Type:** `object`<br/>|
 | `apps.metricsServer.appName` |**None**|**Type:** `string`<br/>|
 | `apps.metricsServer.catalog` |**None**|**Type:** `string`<br/>|
@@ -195,6 +209,13 @@ Properties within the `.apps` top-level object
 | `apps.teleportKubeAgent.inCluster` |**None**|**Type:** `boolean`<br/>|
 | `apps.teleportKubeAgent.namespace` |**None**|**Type:** `string`<br/>|
 | `apps.teleportKubeAgent.version` |**None**|**Type:** `string`<br/>|
+
+### Delete options
+Properties within the `.deleteOptions` top-level object
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `deleteOptions.moveAppsHelmOwnershipToClusterCloudDirector` | **Move Apps Helm ownership to cluster-cloud-director** - Don't delete Apps' Helm charts in the workload cluster. After the update, cluster-cloud-director will recreate App CRs and new App CRs will take over the reconciliation of the existing Chart CRs in the workload cluster.|**Type:** `boolean`<br/>**Default:** `false`|
 
 ### Other
 

--- a/helm/default-apps-cloud-director/templates/apps.yaml
+++ b/helm/default-apps-cloud-director/templates/apps.yaml
@@ -10,6 +10,11 @@ metadata:
     # app-operator will make sure that the app on which it depends is installed before
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
     {{- end }}
+    {{- if and $.Values.deleteOptions.moveAppsHelmOwnershipToClusterCloudDirector (not .inCluster) }}
+    {{- /* We add pause annotation to all apps except bundles (.inCluster==true), because we
+           delete bundles from the MC in order to trigger correct deletion of bundled apps. */}}
+    app-operator.giantswarm.io/paused: "true"
+    {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
     {{- if .inCluster }}

--- a/helm/default-apps-cloud-director/templates/move-apps-to-cluster-cloud-director..yaml
+++ b/helm/default-apps-cloud-director/templates/move-apps-to-cluster-cloud-director..yaml
@@ -1,0 +1,114 @@
+{{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterCloudDirector }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-cloud-director
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-cloud-director
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups: ["application.giantswarm.io"]
+  resources: ["apps"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-cloud-director
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-cloud-director
+  namespace: "{{ $.Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-cloud-director
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-cloud-director
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "0"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 2592000 # 30 days
+  template:
+    metadata:
+      name: {{ $.Values.clusterName }}-move-apps-to-cluster-cloud-director
+      namespace: "{{ $.Release.Namespace }}"
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $.Values.clusterName }}-move-apps-to-cluster-cloud-director
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: remove-app-operator-finalizer
+        image: gsoci.azurecr.io/giantswarm/kubectl:1.29.7
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        command:
+        - "/bin/sh"
+        - "-xc"
+        - |
+          NAMESPACE="{{ $.Release.Namespace }}"
+          echo "Remove app-operator finalizer for all Apps owned by default-apps-cloud-director (except bundles that we want to delete regularly)"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-cloud-director,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
+            case "$app_name" in
+              *bundle*)
+                echo "do nothing for bundles"
+                ;;
+              *)
+                kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+                ;;
+            esac
+          done
+          echo "Remove app-operator finalizer from all observability-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-observability-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+          done
+          echo "Remove app-operator finalizer from all security-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-security-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+          done
+{{- end }}

--- a/helm/default-apps-cloud-director/templates/propagate-pause-to-bundled-apps.yaml
+++ b/helm/default-apps-cloud-director/templates/propagate-pause-to-bundled-apps.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterCloudDirector }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups: ["application.giantswarm.io"]
+  resources: ["apps"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ $.Values.clusterName }}-propagate-pause
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "0"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 2592000 # 30 days
+  template:
+    metadata:
+      name: {{ $.Values.clusterName }}-propagate-pause
+      namespace: "{{ $.Release.Namespace }}"
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $.Values.clusterName }}-propagate-pause
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: propagate-pause
+        image: gsoci.azurecr.io/giantswarm/kubectl:1.29.7
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        command:
+        - "/bin/sh"
+        - "-xc"
+        - |
+          NAMESPACE="{{ $.Release.Namespace }}"
+          echo "Add pause annotation to all observability-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-observability-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"app-operator.giantswarm.io/paused": "true"}}}'
+          done
+          echo "Add pause annotation to all security-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-security-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"app-operator.giantswarm.io/paused": "true"}}}'
+          done
+{{- end }}

--- a/helm/default-apps-cloud-director/values.schema.json
+++ b/helm/default-apps-cloud-director/values.schema.json
@@ -119,6 +119,18 @@
             "minLength": 1,
             "type": "string"
         },
+        "deleteOptions": {
+            "type": "object",
+            "title": "Delete options",
+            "properties": {
+                "moveAppsHelmOwnershipToClusterCloudDirector": {
+                    "type": "boolean",
+                    "title": "Move Apps Helm ownership to cluster-cloud-director",
+                    "description": "Don't delete Apps' Helm charts in the workload cluster. After the update, cluster-cloud-director will recreate App CRs and new App CRs will take over the reconciliation of the existing Chart CRs in the workload cluster.",
+                    "default": false
+                }
+            }
+        },
         "managementCluster": {
             "minLength": 1,
             "type": "string"

--- a/helm/default-apps-cloud-director/values.yaml
+++ b/helm/default-apps-cloud-director/values.yaml
@@ -1,6 +1,8 @@
 clusterName: ""
 organization: ""
 managementCluster: ""
+deleteOptions:
+  moveAppsHelmOwnershipToClusterCloudDirector: false
 
 userConfig:
   certExporter:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/31701

This PR:

- adds a flag which allows migration of apps to the cluster chart

### Checklist

- [x] Update changelog in CHANGELOG.md, **check all commits are in it before release (renovate included)**.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
